### PR TITLE
Add types to ZodContext.invalid

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -41,12 +41,12 @@ export type Method =
   | 'unlock'
   | 'unsubscribe';
 
-export interface ZodRouterInvalid {
-  body?: ZodError;
-  headers?: ZodError;
-  params?: ZodError;
-  query?: ZodError;
-  files?: ZodError;
+export interface ZodRouterInvalid<Headers, Params, Query, Body, Files> {
+  body?: ZodError<Body>;
+  headers?: ZodError<Headers>;
+  params?: ZodError<Params>;
+  query?: ZodError<Query>;
+  files?: ZodError<Files>;
   error?: boolean;
 }
 
@@ -63,7 +63,7 @@ export interface ZodContext<Headers, Params, Query, Body, Files> extends Context
     query: Query;
     files: Files;
   } & Request;
-  invalid: ZodRouterInvalid;
+  invalid: ZodRouterInvalid<Headers, Params, Query, Body, Files>;
 }
 
 export type ValidationOptions<Headers, Params, Query, Body, Files, Response> = {


### PR DESCRIPTION
I've been trying to use this router in a project of mine, where I would like to handle validation my way (I return html `<form>` and I want to embed the errors in it) and ran into issue with types for the `ctx.invalid`. Since it didn't give any type to `ZodError`, it had no properties and I had to force them via type assertion.

This PR tries to fix that, I hope I did it right. Everything seems to build, tests do pass.