### PR TITLE
Fixes #55 - replace koa-bodyparser by @koa/bodyparser

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Inspired by koa-joi-router, this package aims to provide a similar feature-set w
 
 [zod]: https://github.com/colinhacks/zod
 [coercion]: https://zod.dev/?id=coercion-for-primitives
-[koa-bodyparser]: https://github.com/koajs/bodyparser
+[@koa/bodyparser]: https://github.com/koajs/bodyparser
 [formidable]: https://github.com/node-formidable/formidable
 [@koa/router]: https://github.com/koajs/router
 
 ## 🔥 Features:
 
 - Input/output validation and typesafety using [zod][]
-- Body parsing using [koa-bodyparser][]
+- Body parsing using [@koa/bodyparser][]
 - Multipart parsing using [formidable][]
 - Wraps [@koa/router][], providing the same API but with typesafety and validation.
 - Custom validation error handling support
@@ -266,7 +266,7 @@ fileRouter.register({
 ```
 
 ## Custom Validation Error Handling
-`koa-zod-router` allows users to implement router-wide error handling or route specific error handling. 
+`koa-zod-router` allows users to implement router-wide error handling or route specific error handling.
 
 ### Router-wide error handling
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -6,7 +6,7 @@
 
 | Param        | Type                | Description                                                                              |
 | ------------ | ------------------- | ---------------------------------------------------------------------------------------- |
-| [bodyParser] | <code>Object</code> | koa-bodyparser [options](https://github.com/koajs/bodyparser#options)                    |
+| [bodyParser] | <code>Object</code> | @koa/bodyparser [options](https://github.com/koajs/bodyparser?tab=readme-ov-file#options) |
 | [formidable] | <code>Object</code> | formidable [options](https://github.com/node-formidable/formidable#options)              |
 | [koaRouter]  | <code>Object</code> | @koa/router [options](https://github.com/koajs/router/blob/master/API.md#new-routeropts) |
 | [zodRouter]  | <code>Object</code> | koa-zod-router [options](#koa-zod-router-options)                                        |

--- a/package.json
+++ b/package.json
@@ -34,12 +34,11 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@koa/bodyparser": "^6.0.0",
     "@koa/router": "^12.0.1",
     "@types/formidable": "^2.0.6",
-    "@types/koa-bodyparser": "^4.3.11",
     "@types/koa__router": "^12.0.2",
     "formidable": "^2.1.2",
-    "koa-bodyparser": "^4.4.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
+import type { BodyParserOptions } from '@koa/bodyparser/dist/body-parser.types';
 import KoaRouter, { LayerOptions, RouterOptions } from '@koa/router';
 import formidable from 'formidable';
 import { Context, DefaultState, Middleware, Request, Response } from 'koa';
-import bodyParser from 'koa-bodyparser';
 import z, { ZodError, ZodSchema } from 'zod';
 import zodRouter from './zod-router';
 
@@ -123,7 +123,7 @@ export type ZodRouter = ReturnType<typeof zodRouter>;
 export type ValidationErrorHandler<S = DefaultState> = ZodMiddleware<S, any, any, any, any, any, any>;
 
 export interface RouterOpts {
-  bodyParser?: bodyParser.Options;
+  bodyParser?: BodyParserOptions;
   formidable?: formidable.Options;
   koaRouter?: RouterOptions;
   zodRouter?: {

--- a/src/zod-router.ts
+++ b/src/zod-router.ts
@@ -1,21 +1,21 @@
-import bodyParser from 'koa-bodyparser';
+import bodyParser from '@koa/bodyparser';
 import KoaRouter, { ParamMiddleware } from '@koa/router';
+import { DefaultContext, DefaultState } from 'koa';
+import { ZodTypeAny } from 'zod';
+import { multipartParserMiddleware } from './multipart-parser-middleware';
 import {
   Method,
   RegisterSpec,
-  Spec,
-  ValidationOptions,
   RouterMethods,
-  ZodMiddleware,
   RouterOpts,
   RouteSpec,
+  Spec,
   UseSpec,
+  ValidationOptions,
+  ZodMiddleware,
 } from './types';
 import { assertHandlers, assertPath, assertRouteFnSpec, assertUseSpec, methods, prepareMiddleware } from './util';
 import { validationMiddleware } from './validation-middleware';
-import { multipartParserMiddleware } from './multipart-parser-middleware';
-import { DefaultContext, DefaultState } from 'koa';
-import { ZodTypeAny } from 'zod';
 
 const zodRouter = <RouterState = DefaultState>(opts?: RouterOpts) => {
   const _router = new KoaRouter<RouterState>(opts?.koaRouter);


### PR DESCRIPTION
I may need `patchNode` option from the maintained library, the old abandoned library does not have that option, also since 5.0.0 the package is in Typescript, no need to add type definitions from external package.